### PR TITLE
Implementation of audit of entity field changes

### DIFF
--- a/delivery/src/main/java/com/epages/microservice/handson/delivery/DeliveryOrder.java
+++ b/delivery/src/main/java/com/epages/microservice/handson/delivery/DeliveryOrder.java
@@ -15,6 +15,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+import com.epages.microservice.handson.shared.jpa.Audited;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 @Entity
@@ -33,6 +34,7 @@ public class DeliveryOrder implements Serializable {
     @Column(name = "ORDER_LINK", length = 255, unique = true, nullable = false)
     private URI orderLink;
 
+    @Audited
     @Enumerated(EnumType.STRING)
     @Column(name = "DELIVERY_ORDER_STATE", length = 30, nullable = false)
     private DeliveryOrderState deliveryOrderState;

--- a/delivery/src/main/resources/META-INF/services/org.hibernate.integrator.spi.Integrator
+++ b/delivery/src/main/resources/META-INF/services/org.hibernate.integrator.spi.Integrator
@@ -1,0 +1,1 @@
+com.epages.microservice.handson.hibernate.HibernateIntegrator

--- a/delivery/src/test/java/com/epages/microservice/handson/delivery/DeliveryOrderRepositoryTest.java
+++ b/delivery/src/test/java/com/epages/microservice/handson/delivery/DeliveryOrderRepositoryTest.java
@@ -3,49 +3,201 @@ package com.epages.microservice.handson.delivery;
 import static org.assertj.core.api.BDDAssertions.then;
 
 import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.epages.microservice.handson.shared.jpa.EntityAudit;
+import com.epages.microservice.handson.shared.jpa.EntityAuditRepository;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @DeliveryApplicationTest(activeProfiles = { "test", "DeliveryServiceTest" })
 public class DeliveryOrderRepositoryTest {
 
+    private static final URI ORDER_LINK = URI.create("http://localhost/orders/1");
+    
+    private static final String DELIVERY_ORDER_TABLE_NAME = "DELIVERY_ORDER";
+    
+    private static final String DELIVERY_ORDER_STATE_FIELD_NAME = "DELIVERY_ORDER_STATE";
+    
     @Autowired
     private DeliveryOrderRepository deliveryOrderRepository;
 
-    private DeliveryOrder deliveryOrder;
-
+    @Autowired
+    private EntityAuditRepository entityAuditRepository;
+    
     @After
     public  void cleanup() {
         deliveryOrderRepository.deleteAll();
+        entityAuditRepository.deleteAll();
     }
 
-    private void givenDeliveryOrder(DeliveryOrderState deliveryOrderState) {
-        deliveryOrder = new DeliveryOrder();
-        deliveryOrder.setOrderLink(URI.create("http://localhost/orders/1"));
+    private DeliveryOrder getDeliveryOrder(DeliveryOrderState deliveryOrderState) {
+        return getDeliveryOrder(deliveryOrderState, ORDER_LINK);
+    }
+    
+    private DeliveryOrder getDeliveryOrder(DeliveryOrderState deliveryOrderState, URI uri) {
+        DeliveryOrder deliveryOrder = new DeliveryOrder();
+        deliveryOrder.setOrderLink(uri);
         deliveryOrder.setDeliveryOrderState(deliveryOrderState);
-    }
-
-    private Long whenDeliveryOrderIsSaved() {
-        return deliveryOrderRepository.saveAndFlush(deliveryOrder).getId();
+        return deliveryOrder;
     }
 
     @Test
     public void should_save_delivery_order() {
+        
+        DeliveryOrder order = deliveryOrderRepository.saveAndFlush(getDeliveryOrder(DeliveryOrderState.QUEUED));
 
-        givenDeliveryOrder(DeliveryOrderState.QUEUED);
-
-        Long id = whenDeliveryOrderIsSaved();
-
-        then(id).isNotNull();
+        //check that event listeners did not affect on saved object
+        assertDeliveryOrder(order, ORDER_LINK, DeliveryOrderState.QUEUED);
     }
 
     @Test
     public void should_save_delivery_order_with_history() {
-        // TODO implement me
+        
+        DeliveryOrder order = deliveryOrderRepository.save(getDeliveryOrder(DeliveryOrderState.QUEUED));
+        
+        assertDeliveryOrder(order, ORDER_LINK, DeliveryOrderState.QUEUED);
+        
+        List<EntityAudit> allAudit = entityAuditRepository.findAll();
+        
+        then(allAudit.size()).isEqualTo(1);
+        assertAudit(allAudit.get(0), 
+                    DELIVERY_ORDER_TABLE_NAME, 
+                    DELIVERY_ORDER_STATE_FIELD_NAME, 
+                    order.getId(), 
+                    DeliveryOrderState.QUEUED.name());
+    }
+    
+    @Test
+    public void should_update_delivery_order_with_history() {
+        
+        DeliveryOrder order = deliveryOrderRepository.save(getDeliveryOrder(DeliveryOrderState.QUEUED));
+        
+        order.setDeliveryOrderState(DeliveryOrderState.IN_PROGRESS);
+        deliveryOrderRepository.save(order);
+        
+        assertDeliveryOrder(order, ORDER_LINK, DeliveryOrderState.IN_PROGRESS);
+        
+        List<EntityAudit> allAudit = entityAuditRepository.findAll();
+        
+        then(allAudit.size()).isEqualTo(2);
+        allAudit = allAudit.stream()
+                           .sorted((a1, a2) -> Long.compare(a1.getId(), a2.getId()))
+                           .collect(Collectors.toList());
+        
+        assertAudit(allAudit.get(0), 
+                    DELIVERY_ORDER_TABLE_NAME, 
+                    DELIVERY_ORDER_STATE_FIELD_NAME, 
+                    order.getId(), 
+                    DeliveryOrderState.QUEUED.name());
+        
+        assertAudit(allAudit.get(1), 
+                    DELIVERY_ORDER_TABLE_NAME, 
+                    DELIVERY_ORDER_STATE_FIELD_NAME, 
+                    order.getId(), 
+                    DeliveryOrderState.IN_PROGRESS.name());
+    }
+    
+    @Test
+    public void should_update_delivery_order_without_history() {
+        
+        URI uriForUpdate = URI.create("http://localhost/orders/2");
+        
+        DeliveryOrder order = deliveryOrderRepository.save(getDeliveryOrder(DeliveryOrderState.QUEUED));
+        
+        order.setOrderLink(uriForUpdate);
+        deliveryOrderRepository.save(order);
+        
+        assertDeliveryOrder(order, uriForUpdate, DeliveryOrderState.QUEUED);
+        
+        List<EntityAudit> allAudit = entityAuditRepository.findAll();
+        
+        then(allAudit.size()).isEqualTo(1);
+        
+        assertAudit(allAudit.get(0), 
+                    DELIVERY_ORDER_TABLE_NAME, 
+                    DELIVERY_ORDER_STATE_FIELD_NAME, 
+                    order.getId(), 
+                    DeliveryOrderState.QUEUED.name());
+    }
+    
+    @Test
+    public void should_delete_delivery_order_with_history() {
+        
+        DeliveryOrder order = deliveryOrderRepository.save(getDeliveryOrder(DeliveryOrderState.QUEUED));
+        
+        deliveryOrderRepository.save(order);
+        deliveryOrderRepository.delete(order);
+        
+        List<DeliveryOrder> allOrders = deliveryOrderRepository.findAll();
+        then(allOrders.size()).isEqualTo(0);
+        
+        List<EntityAudit> allAudit = entityAuditRepository.findAll();
+        then(allAudit.size()).isEqualTo(2);
+        
+        allAudit = allAudit.stream()
+                           .sorted((a1, a2) -> Long.compare(a1.getId(), a2.getId()))
+                           .collect(Collectors.toList());
+        
+        assertAudit(allAudit.get(0), 
+                    DELIVERY_ORDER_TABLE_NAME, 
+                    DELIVERY_ORDER_STATE_FIELD_NAME, 
+                    order.getId(), 
+                    DeliveryOrderState.QUEUED.name());
+        
+        assertAudit(allAudit.get(1), 
+                    DELIVERY_ORDER_TABLE_NAME, 
+                    DELIVERY_ORDER_STATE_FIELD_NAME, 
+                    order.getId(), 
+                    null);
+    }
+    
+    @Test
+    public void should_not_update_delivery_order_without_history() {
+        
+        DeliveryOrder order = getDeliveryOrder(DeliveryOrderState.QUEUED);
+        deliveryOrderRepository.save(order);
+        
+        order.setOrderLink(null);
+        order.setDeliveryOrderState(DeliveryOrderState.IN_PROGRESS);
+        try {
+            deliveryOrderRepository.save(order);
+            Assert.fail();
+        } catch(DataIntegrityViolationException ve) {
+        }
+        
+        order = deliveryOrderRepository.findOne(order.getId());
+        assertDeliveryOrder(order, ORDER_LINK, DeliveryOrderState.QUEUED);
+        
+        List<EntityAudit> allAudit = entityAuditRepository.findAll();
+        then(allAudit.size()).isEqualTo(1);
+
+        assertAudit(allAudit.get(0), 
+                    DELIVERY_ORDER_TABLE_NAME, 
+                    DELIVERY_ORDER_STATE_FIELD_NAME, 
+                    order.getId(), 
+                    DeliveryOrderState.QUEUED.name());
+    }
+    
+    private void assertDeliveryOrder(DeliveryOrder actual, URI orderLink, DeliveryOrderState deliveryOrderState) {
+        then(actual.getId()).isNotNull();
+        then(actual.getOrderLink()).isEqualTo(orderLink);
+        then(actual.getDeliveryOrderState()).isEqualTo(deliveryOrderState);
+    }
+    
+    private void assertAudit(EntityAudit actual, String entityName, String fieldName, Long entityId, String state) {
+        then(actual.getEntityName()).isEqualTo(entityName);
+        then(actual.getEntityId()).isEqualTo(entityId);
+        then(actual.getFieldName()).isEqualTo(fieldName);
+        then(actual.getState()).isEqualTo(state);
+        then(actual.getId()).isNotNull();
     }
 }

--- a/shared/src/main/java/com/epages/microservice/handson/hibernate/EntityAuditListener.java
+++ b/shared/src/main/java/com/epages/microservice/handson/hibernate/EntityAuditListener.java
@@ -1,0 +1,116 @@
+package com.epages.microservice.handson.hibernate;
+
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.persistence.Column;
+import javax.persistence.Table;
+
+import org.hibernate.event.spi.EventSource;
+import org.hibernate.event.spi.PostInsertEvent;
+import org.hibernate.event.spi.PostInsertEventListener;
+import org.hibernate.event.spi.PreDeleteEvent;
+import org.hibernate.event.spi.PreDeleteEventListener;
+import org.hibernate.event.spi.PreUpdateEvent;
+import org.hibernate.event.spi.PreUpdateEventListener;
+import org.hibernate.persister.entity.EntityPersister;
+
+import com.epages.microservice.handson.shared.jpa.Audited;
+import com.epages.microservice.handson.shared.jpa.EntityAudit;
+
+public class EntityAuditListener implements PreUpdateEventListener, PreDeleteEventListener, PostInsertEventListener {
+
+    private static final long serialVersionUID = 9120073823777698089L;
+
+    @Override
+    public boolean onPreDelete(PreDeleteEvent event) {
+        auditEntityChanges(event.getPersister(), 
+                           event.getSession(), 
+                           event.getEntity(), 
+                           Optional.ofNullable(event.getDeletedState()), 
+                           Optional.empty());
+        return false;
+    }
+
+    @Override
+    public boolean onPreUpdate(PreUpdateEvent event) {
+        auditEntityChanges(event.getPersister(), 
+                           event.getSession(), 
+                           event.getEntity(), 
+                           Optional.ofNullable(event.getOldState()), 
+                           Optional.ofNullable(event.getState()));
+        return false;
+    }
+
+    @Override
+    public void onPostInsert(PostInsertEvent event) {
+        auditEntityChanges(event.getPersister(), 
+                           event.getSession(), 
+                           event.getEntity(), 
+                           Optional.empty(), 
+                           Optional.ofNullable(event.getState()));
+    }
+    
+    private void auditEntityChanges(EntityPersister persister,
+                                    EventSource session,
+                                    Object entity,
+                                    Optional<Object[]> oldState, 
+                                    Optional<Object[]> newState){
+        
+        String[] fieldNames = persister.getEntityMetamodel().getPropertyNames();
+        Class<?> clazz = persister.getClassMetadata().getMappedClass();
+        Serializable id = persister.getIdentifier(entity, session);
+        
+        if(fieldNames == null || fieldNames.length == 0){
+            throw new IllegalStateException(String.format("Entity %s has no fields", clazz));
+        }
+        
+        for(int i = 0; i < fieldNames.length; i++){
+            final int fieldIndex = i;
+            Object oldValue = oldState.map(state -> state[fieldIndex]).orElse(null);
+            Object newValue = newState.map(state -> state[fieldIndex]).orElse(null);
+            
+            try {
+                auditFieldChangeIfNeed(id, clazz, fieldNames[fieldIndex], oldValue, newValue, session);
+            } catch (NoSuchFieldException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    private void auditFieldChangeIfNeed(Serializable id,
+                                         Class<?> clazz,
+                                         String fieldName,
+                                         Object oldValue, 
+                                         Object newValue,
+                                         EventSource session) throws NoSuchFieldException {
+
+        Field field = clazz.getDeclaredField(fieldName);
+
+        Audited audited = field.getAnnotation(Audited.class);
+        if(audited == null || Objects.equals(oldValue, newValue)){
+            return;
+        }
+
+        if(id == null){
+            throw new IllegalStateException(String.format("Audited entity %s has empty id", clazz));
+        }
+
+        if(!Number.class.isAssignableFrom(id.getClass())){
+            throw new IllegalStateException(String.format("Audited entity %s should have id which is instance of Number", clazz));
+        }
+
+        String entityName = Optional.ofNullable(clazz.getAnnotation(Table.class)).map(t -> t.name()).orElse(clazz.getName());
+        String auditedFieldName = Optional.ofNullable(field.getAnnotation(Column.class)).map(c -> c.name()).orElse(fieldName);
+        long auditedId = ((Number)id).longValue();
+
+        session.save(new EntityAudit(entityName, auditedFieldName, auditedId, Objects.toString(newValue, null)));
+    }
+
+    @Override
+    public boolean requiresPostCommitHanding(EntityPersister persister) {
+        return false;
+    }
+}

--- a/shared/src/main/java/com/epages/microservice/handson/hibernate/HibernateIntegrator.java
+++ b/shared/src/main/java/com/epages/microservice/handson/hibernate/HibernateIntegrator.java
@@ -1,0 +1,38 @@
+package com.epages.microservice.handson.hibernate;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.integrator.spi.Integrator;
+import org.hibernate.metamodel.source.MetadataImplementor;
+import org.hibernate.service.spi.SessionFactoryServiceRegistry;
+
+public class HibernateIntegrator implements Integrator {
+
+    @Override
+    public void integrate(Configuration configuration,
+                          SessionFactoryImplementor sessionFactory,
+                          SessionFactoryServiceRegistry serviceRegistry) {
+        
+        EventListenerRegistry eventListenerRegistry = serviceRegistry.getService(EventListenerRegistry.class);
+
+        EntityAuditListener listener = new EntityAuditListener(); 
+
+        eventListenerRegistry.appendListeners(EventType.POST_INSERT, listener);
+        eventListenerRegistry.appendListeners(EventType.PRE_UPDATE, listener);
+        eventListenerRegistry.appendListeners(EventType.PRE_DELETE, listener);
+    }
+
+    @Override
+    public void integrate(MetadataImplementor metadata, 
+                          SessionFactoryImplementor sessionFactory, 
+                          SessionFactoryServiceRegistry serviceRegistry) {
+    }
+
+    @Override
+    public void disintegrate(SessionFactoryImplementor sessionFactory, 
+                             SessionFactoryServiceRegistry serviceRegistry) {
+    }
+
+}

--- a/shared/src/main/java/com/epages/microservice/handson/shared/jpa/Audited.java
+++ b/shared/src/main/java/com/epages/microservice/handson/shared/jpa/Audited.java
@@ -1,0 +1,12 @@
+package com.epages.microservice.handson.shared.jpa;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD })
+public @interface Audited {
+
+}

--- a/shared/src/main/java/com/epages/microservice/handson/shared/jpa/EntityAudit.java
+++ b/shared/src/main/java/com/epages/microservice/handson/shared/jpa/EntityAudit.java
@@ -1,0 +1,127 @@
+package com.epages.microservice.handson.shared.jpa;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static javax.persistence.GenerationType.IDENTITY;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "ENTITY_AUDIT")
+public class EntityAudit {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "ID", nullable = false)
+    private Long id;
+    
+    @Column(name="ENTITY_NAME", updatable = false, nullable = false)
+    private String entityName;
+    
+    @Column(name="FIELD_NAME", updatable = false, nullable = false)
+    private String fieldName;
+    
+    @Column(name="ENTITY_ID", updatable = false, nullable = false)
+    private long entityId;
+    
+    @Column(name="STATE", updatable = false)
+    private String state;
+    
+    @Column(name="EVENT_TIME", updatable = false, nullable = false)
+    private Date eventTime;
+
+    public EntityAudit() {
+    }
+
+    public EntityAudit(String entityName, String fieldName, long entityId, String state) {
+        this.entityName = entityName;
+        this.fieldName = fieldName;
+        this.entityId = entityId;
+        this.state = state;
+        this.eventTime = new Date();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getEntityName() {
+        return entityName;
+    }
+
+    public void setEntityName(String entityName) {
+        this.entityName = entityName;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public void setFieldName(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public long getEntityId() {
+        return entityId;
+    }
+
+    public void setEntityId(long entityId) {
+        this.entityId = entityId;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public Date getEventTime() {
+        return eventTime;
+    }
+
+    public void setEventTime(Date eventTime) {
+        this.eventTime = eventTime;
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        EntityAudit that = (EntityAudit) o;
+
+        return !(id != null ? !id.equals(that.id) : that.id != null);
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this).add("id", id)
+                                   .add("entityName", entityName)
+                                   .add("fieldName", fieldName)
+                                   .add("entityId", entityId)
+                                   .add("state", state)
+                                   .add("eventTime", eventTime)
+                                   .toString();
+    }
+
+}

--- a/shared/src/main/java/com/epages/microservice/handson/shared/jpa/EntityAuditRepository.java
+++ b/shared/src/main/java/com/epages/microservice/handson/shared/jpa/EntityAuditRepository.java
@@ -1,0 +1,7 @@
+package com.epages.microservice.handson.shared.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EntityAuditRepository extends JpaRepository<EntityAudit, Long>{
+
+}


### PR DESCRIPTION
Motivation of implement based on hibernate event listeners audit:

There are few ways to implement audit of entity field changes. Each layer can contain audit logic

Database -> JDBC -> ORM(Hibernate/JPA) -> Spring-Data(Repository) -> Service - > REST Controller -> HTTP Client

Usually, audit should be in lower possible level and contain few possible ways to write into database without audit.
* Database. Logic (triggers) in database is good way for security reasons, 
but support such logic on database is more complex, triggers is implicit and developer can forget about it when develop some new features or remove old features.
In this task t think we have no strict security reasons for audit. So for this task it is not good way.

* JDBC. As I now have not trigger features and it is not comfortable way to work directly with JDBC.

* ORM. Unfortunatelly, JPA has no appropriate audit feature. It has entity listeners, but they forbid saving entities inside of listener methods and have no features for get old and new state of field.
But hibernate has two good features.

  * Hibernate envers: best way for audit if application use hibernate directly without JPA. 
It requires only add annotation (@Audited) on audited field and add hibernate-envers dependency.
This is problem if application use JPA because JPA should not have hibernate annotations (only JPA).
Explicit setting hibernate envers version in dependencies is inappropriate usually for spring boot application.
I created draft example of hibernate envers audit in separated branch https://github.com/chernatkin/team-black-assessment/tree/assessment-envers

  * **Hibernate event listeners**: good way for save audit data on insert, update, delete actions. Allows get old state and new state of field.
I chose this way for this task. It is sort of hibernate envers implementation but not such advanced as hibernate envers.

* Spring-Data. Spring-data has no appropriate audit feature. 
It is possible implement audit in repository by overriding save and delete methods in repository or adding aspect on this methods, 
but it there was complex to get old and new state of auditable fields.
And some developer may accidentally save entity without repository via entity manager and than audit will not be written.